### PR TITLE
Fix nav-v2 links

### DIFF
--- a/agent/notes/fix-ru-nav-v2.md
+++ b/agent/notes/fix-ru-nav-v2.md
@@ -1,0 +1,14 @@
+# Task: Fix Russian v2 navigation text
+
+## Summary
+
+Replaced English link texts with Russian equivalents in `tmpl/web/ru/inc/nav-v2.html`.
+
+## Observations
+
+- "Landing", "Blog", and "Hybrid" are now "Лендинг", "Блог", and "Гибрид".
+- Documentation links are localized as "CLI", "Разработка LLM", "Частые вопросы", "Плагины", and "Устранение неполадок".
+
+## Suggestions
+
+- Consider aligning page titles with these Russian terms for consistency.

--- a/agent/notes/update-nav-v2.md
+++ b/agent/notes/update-nav-v2.md
@@ -1,0 +1,15 @@
+# Task: Update Russian v2 navigation
+
+## Summary
+
+Added links to all documentation pages under `tmpl/web/ru/v2/docs/`.
+This ensures every page in the v2 structure is reachable from the navigation menu.
+
+## Observations
+
+- Previously missing pages like `cli.html` and `plugins.html` are now present.
+- Navigation structure is still simple: single-level examples and docs sections.
+
+## Suggestions
+
+- Consider ordering docs logically or by importance once real content is added.

--- a/tmpl/web/ru/inc/nav-v2.html
+++ b/tmpl/web/ru/inc/nav-v2.html
@@ -6,26 +6,32 @@
                 <span class="home-text">Главная</span>
             </a>
         </li>
+        <li><a href="/{{ locale }}/v2/about.html">О проекте</a></li>
+        <li><a href="/{{ locale }}/v2/features.html">Возможности</a></li>
         <li>
-            <span>Возможности</span>
+            <span>Примеры</span>
             <ul>
-                <li><a href="/{{ locale }}/v2/features/content-as-code.html">Контент как код</a></li>
-                <li><a href="/{{ locale }}/v2/features/ai-localization.html">AI Локализация</a></li>
-                <li><a href="/{{ locale }}/v2/features/file-based.html">Файловая CMS</a></li>
-                <li><a href="/{{ locale }}/v2/features/ssr.html">SSR</a></li>
+                <li><a href="/{{ locale }}/v2/examples/landing.html">Лендинг</a></li>
+                <li><a href="/{{ locale }}/v2/examples/blog.html">Блог</a></li>
+                <li><a href="/{{ locale }}/v2/examples/hybrid.html">Гибрид</a></li>
             </ul>
         </li>
         <li>
             <span>Документация</span>
             <ul>
-                <li><a href="/{{ locale }}/v2/docs/about.html">О проекте</a></li>
+                <li><a href="/{{ locale }}/v2/docs/overview.html">Обзор</a></li>
                 <li><a href="/{{ locale }}/v2/docs/install.html">Установка</a></li>
                 <li><a href="/{{ locale }}/v2/docs/config.html">Конфигурация</a></li>
                 <li><a href="/{{ locale }}/v2/docs/locales.html">Локали</a></li>
                 <li><a href="/{{ locale }}/v2/docs/translate.html">Переводы</a></li>
+                <li><a href="/{{ locale }}/v2/docs/cli.html">CLI</a></li>
+                <li><a href="/{{ locale }}/v2/docs/dev-llm.html">Разработка LLM</a></li>
+                <li><a href="/{{ locale }}/v2/docs/faq.html">Частые вопросы</a></li>
+                <li><a href="/{{ locale }}/v2/docs/plugins.html">Плагины</a></li>
+                <li><a href="/{{ locale }}/v2/docs/troubleshooting.html">Устранение неполадок</a></li>
             </ul>
         </li>
-        <li><a href="/{{ locale }}/v2/contact.html">Контакты</a></li>
+        <li><a href="/{{ locale }}/v2/roadmap.html">Дорожная карта</a></li>
     </ul>
 
     <div class="nav-right">


### PR DESCRIPTION
## Summary
- clean the Russian v2 navigation menu
- remove links to v1 pages and add links matching the v2 folder
- include remaining doc pages under docs section
- localize all nav link texts in Russian

## Testing
- `npm run start -- --help` *(fails: server started, then aborted)*


------
https://chatgpt.com/codex/tasks/task_e_6874dc57c0a8832d9f07aaefcc4a75f1