### PR TITLE
Add contacts page per site structure

### DIFF
--- a/agent/notes/2025/07-17-add-contacts-v2.md
+++ b/agent/notes/2025/07-17-add-contacts-v2.md
@@ -1,0 +1,12 @@
+# Task: Add missing contacts page and links
+
+## Summary
+- Created `contacts.html` in `tmpl/web/ru/v2/` and `tmpl/web/en/v2/`.
+- Updated Russian and English navigators (`nav-v2.html`) to link to the new page.
+
+## Observations
+- The structure documentation lists `contacts.html` under `/v2/` but it was absent in both locales.
+- Navigation menus lacked a link to this page.
+
+## Suggestions
+- Review existing links on `index.html` that reference non-existent `v2/features.html`.

--- a/tmpl/web/en/inc/nav-v2.html
+++ b/tmpl/web/en/inc/nav-v2.html
@@ -23,6 +23,7 @@
             </ul>
         </li>
         <li><a href="/{{ locale }}/v2/roadmap.html">Roadmap</a></li>
+        <li><a href="/{{ locale }}/v2/contacts.html">Contacts</a></li>
     </ul>
 
     <div class="nav-right">

--- a/tmpl/web/en/v2/contacts.html
+++ b/tmpl/web/en/v2/contacts.html
@@ -1,0 +1,40 @@
+{% extends "inc/layout-v2.html" %}
+
+{% block title %}Contacts and Services — TeqCMS{% endblock %}
+
+{% block content %}
+<h1>Contact Me</h1>
+
+<ul>
+    <li>Email: <a href="mailto:alex@wiredgeese.com">alex@wiredgeese.com</a></li>
+    <li>GitHub: <a href="https://github.com/flancer64" target="_blank">github.com/flancer64</a></li>
+    <li>Telegram: <a href="https://t.me/wiredgeese" target="_blank">@wiredgeese</a></li>
+</ul>
+
+<h2>About Me</h2>
+
+<div class="author-block">
+    <img src="/img/alex.png" alt="Alex Gusev" class="author-photo">
+    <p>I'm Alex Gusev, creator of TeqCMS and TeqFW, a developer with 25+ years of experience. I build systems where content is code, and AI helps automate routine tasks. I use TeqCMS myself in real projects — for example, <a href="https://nutrilog.app.wiredgeese.com/" target="_blank">NutriLog</a>.</p>
+</div>
+
+<h2>How I Can Help</h2>
+
+<ul>
+    <li><strong>Installation</strong> and project setup for your environment</li>
+    <li><strong>AI localization</strong>: configuring translation using LLM API</li>
+    <li><strong>Customization</strong>: templates, logic, CMS components</li>
+    <li><strong>Consulting</strong>: architecture, SSR, CI/CD, deployment</li>
+</ul>
+
+<h2>Terms</h2>
+
+<ul>
+    <li>One-time assistance or ongoing support</li>
+    <li>Migration and production support</li>
+</ul>
+
+<p>Base rate — from <strong>30 €/hour</strong>. Price depends on the task.</p>
+
+<p><a href="mailto:alex@wiredgeese.com">Email me</a> if you want to quickly implement TeqCMS for your project.</p>
+{% endblock %}

--- a/tmpl/web/ru/inc/nav-v2.html
+++ b/tmpl/web/ru/inc/nav-v2.html
@@ -23,6 +23,7 @@
             </ul>
         </li>
         <li><a href="/{{ locale }}/v2/roadmap.html">Дорожная карта</a></li>
+        <li><a href="/{{ locale }}/v2/contacts.html">Контакты</a></li>
     </ul>
 
     <div class="nav-right">

--- a/tmpl/web/ru/v2/contacts.html
+++ b/tmpl/web/ru/v2/contacts.html
@@ -1,0 +1,42 @@
+{% extends "inc/layout-v2.html" %}
+
+{% block title %}Контакты и услуги — TeqCMS{% endblock %}
+
+{% block content %}
+<h1>Связаться со мной</h1>
+
+<ul>
+    <li>Email: <a href="mailto:alex@wiredgeese.com">alex@wiredgeese.com</a></li>
+    <li>GitHub: <a href="https://github.com/flancer64" target="_blank">github.com/flancer64</a></li>
+    <li>Telegram: <a href="https://t.me/wiredgeese" target="_blank">@wiredgeese</a></li>
+</ul>
+
+<h2>Обо мне</h2>
+
+<div class="author-block">
+    <img src="/img/alex.png" alt="Alex Gusev" class="author-photo">
+    <p>Я — Алекс Гусев, автор TeqCMS и TeqFW, разработчик с 25+ годами опыта. Создаю системы, где контент — это код, а
+        AI помогает автоматизировать рутину. TeqCMS я использую сам, в реальных проектах — например, <a
+                href="https://nutrilog.app.wiredgeese.com/" target="_blank">NutriLog</a>.</p>
+</div>
+
+<h2>Чем могу помочь</h2>
+
+<ul>
+    <li><strong>Установка</strong> и запуск проекта под ваше окружение</li>
+    <li><strong>AI-локализация</strong>: настройка перевода с помощью LLM API</li>
+    <li><strong>Кастомизация</strong>: шаблоны, логика, компоненты CMS</li>
+    <li><strong>Консультации</strong>: архитектура, SSR, CI/CD, деплой</li>
+</ul>
+
+<h2>Условия</h2>
+
+<ul>
+    <li>Разовая помощь или сопровождение</li>
+    <li>Поддержка при миграции и продакшене</li>
+</ul>
+
+<p>Базовая ставка — от <strong>30 €/час</strong>. Стоимость зависит от задачи.</p>
+
+<p><a href="mailto:alex@wiredgeese.com">Напишите мне</a>, если хотите быстро внедрить TeqCMS под ваш проект.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create contacts page in /v2 for RU and EN
- link contacts page in both nav-v2 templates
- record analysis notes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879444957cc832d91e13ce0e2767d72